### PR TITLE
required module must match npm module name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install pbauto-nodejs-http
 Create a new PBAuto instance by passing in IP and Port of the Pandoras Box Web Server Service.
 
 ```javascript
-var PBAuto = require('pbauto-node');
+var PBAuto = require('pbauto-nodejs-http');
 
 var connection = new PBAuto("2.0.0.1", 6214);
 ```


### PR DESCRIPTION
It won't work with the current documentation because the required module name is wrong. That was left over from my npm module.